### PR TITLE
Add Déjà Vu publication card above AI For Good

### DIFF
--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -25,6 +25,21 @@
         </div>
       </div>
 
+      <!-- Déjà Vu -->
+      <div class="card p-6 hover:shadow-github transition-shadow duration-150">
+        <div class="flex items-start space-x-4">
+          <div class="flex-shrink-0">
+            <div class="w-10 h-10 mastodon-bg rounded-lg flex items-center justify-center">
+              <i class="fas fa-clock-rotate-left mastodon-accent text-lg"></i>
+            </div>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-lg font-semibold text-github-text mb-2">Déjà Vu</h3>
+            <p class="text-github-text-secondary leading-relaxed">A publication on the science of <a href="https://andygauge.github.io/deja-vu/" class="text-github-accent hover:underline" target="_blank" rel="noopener">déjà vu</a> — memory, dissociation, model drift, and the algorithms that forget for us.</p>
+          </div>
+        </div>
+      </div>
+
       <!-- AI For Good -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">


### PR DESCRIPTION
Introduces a new "What I Do" card for the Déjà Vu publication (https://andygauge.github.io/deja-vu/) — a publication on the science of déjà vu: memory, dissociation, model drift, and the algorithms that forget for us. Placed directly above the AI For Good card. Uses fa-clock-rotate-left for the icon to evoke the time-returning nature of the subject.