### PR TITLE
Rebrand and site content updates

### DIFF
--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -100,6 +100,36 @@
         </div>
       </div>
 
+      <!-- sveltekitbook -->
+      <div class="card p-6 hover:shadow-github transition-shadow duration-150">
+        <div class="flex items-start space-x-4">
+          <div class="flex-shrink-0">
+            <div class="w-10 h-10 mastodon-bg rounded-lg flex items-center justify-center">
+              <i class="fas fa-cube mastodon-accent text-lg"></i>
+            </div>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-lg font-semibold text-github-text mb-2">sveltekitbook</h3>
+            <p class="text-github-text-secondary leading-relaxed"><strong>tl;dr:</strong> the runtime kernel behind every research book on this site — gestures, inline markdown, spectrum palette, and Giscus comments — published as <a href="https://www.npmjs.com/package/sveltekitbook" class="text-github-accent hover:underline" target="_blank" rel="noopener">sveltekitbook</a> on npm. Small on purpose: routes, cover, and per-page layout get scaffolded into each book as editable starter files instead of hiding behind a component API.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- create-sveltekitbook -->
+      <div class="card p-6 hover:shadow-github transition-shadow duration-150">
+        <div class="flex items-start space-x-4">
+          <div class="flex-shrink-0">
+            <div class="w-10 h-10 mastodon-bg rounded-lg flex items-center justify-center">
+              <i class="fas fa-wand-magic-sparkles mastodon-accent text-lg"></i>
+            </div>
+          </div>
+          <div class="flex-1">
+            <h3 class="text-lg font-semibold text-github-text mb-2">create-sveltekitbook</h3>
+            <p class="text-github-text-secondary leading-relaxed"><strong>tl;dr:</strong> the scaffolder for the runtime above. <code class="px-1 py-0.5 bg-github-bg rounded text-sm">npm create sveltekitbook@latest my-book</code> walks a handful of prompts and drops a working SvelteKit book onto disk — cover, content pages, optional glossary / index / authors / topics, and a choice of <em>timeline</em>, <em>spectrum</em>, or flat continuum. Published as <a href="https://www.npmjs.com/package/create-sveltekitbook" class="text-github-accent hover:underline" target="_blank" rel="noopener">create-sveltekitbook</a> on npm.</p>
+          </div>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- New What I Do cards: Déjà Vu, sveltekitbook, create-sveltekitbook
- New blog posts: Skills-Driven Development, MCP-First Development, Organizational Collapse
- Sentinel post typography overhaul (press-style justified prose, floated code figures, 2-column MCP inset)
- Home-page sections refactored to `_data/*.yml` (samples, sections, timeline)
- Timeline entries: 1996/1999 TOBAC, 2018 Barangay/Calamba, Valant + Oregon Health Authority milestones
- FAQ Copilot grammar fix propagated into the include

## Test plan
- [ ] Pull the branch locally and run \`bundle exec jekyll serve\`
- [ ] Verify the three new What I Do cards render in order: Déjà Vu, sveltekitbook, create-sveltekitbook
- [ ] Verify each new blog post renders with the new post typography
- [ ] Verify timeline entries appear in correct year order
- [ ] Smoke-check FAQ rendering on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)