### PR TITLE
Group What I Do cards under section headings

### DIFF
--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -10,6 +10,7 @@
     
     <!-- Mastodon-inspired layout with alternating cards -->
     <div class="max-w-4xl mx-auto space-y-6">
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-2">Work</h3>
       <!-- Multi-Agentic Systems -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -19,12 +20,13 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">Multi-Agentic Systems</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">Multi-Agentic Systems</h4>
             <p class="text-github-text-secondary leading-relaxed">Designing and orchestrating collaborative AI agents that plan, delegate, and execute complex software workflows together, as highlighted on page 8 of <a href="https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf#page=8" class="text-github-accent hover:underline" target="_blank" rel="noopener">Anthropic's 2026 Agentic Coding Trends Report</a>.</p>
           </div>
         </div>
       </div>
 
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Research</h3>
       <!-- Déjà Vu -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -34,7 +36,7 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">Déjà Vu</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">Déjà Vu</h4>
             <p class="text-github-text-secondary leading-relaxed">A publication on the science of <a href="https://andygauge.github.io/deja-vu/" class="text-github-accent hover:underline" target="_blank" rel="noopener">déjà vu</a> — memory, dissociation, model drift, and the algorithms that forget for us.</p>
           </div>
         </div>
@@ -49,12 +51,13 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">AI For Good</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">AI For Good</h4>
             <p class="text-github-text-secondary leading-relaxed">Research into applications of AI through thoughtful, human-focused domains — collected at <a href="https://andygauge.github.io/ai-for-good/" class="text-github-accent hover:underline" target="_blank" rel="noopener">AI For Good</a>.</p>
           </div>
         </div>
       </div>
 
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Governance</h3>
       <!-- Rust Cookbook -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -64,12 +67,13 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">Rust Cookbook</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">Rust Cookbook</h4>
             <p class="text-github-text-secondary leading-relaxed">Rust-lang project lead on <a href="https://rust-lang-nursery.github.io/rust-cookbook/" class="text-github-accent hover:underline" target="_blank" rel="noopener">The Rust Cookbook</a>, making complex computer science tools accessible to everyone.</p>
           </div>
         </div>
       </div>
 
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Advocacy</h3>
       <!-- MCP Authorization -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -79,12 +83,13 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">MCP Authorization</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">MCP Authorization</h4>
             <p class="text-github-text-secondary leading-relaxed">Author of the <code class="px-1 py-0.5 bg-github-bg rounded text-sm">mcp_authorization</code> libraries across five languages — <a href="https://github.com/onboardiq/mcp_authorization" class="text-github-accent hover:underline" target="_blank" rel="noopener">Ruby</a>, <a href="https://github.com/onboardiq/mcp_authorization_node" class="text-github-accent hover:underline" target="_blank" rel="noopener">Node</a>, <a href="https://github.com/onboardiq/mcp-authorization-python" class="text-github-accent hover:underline" target="_blank" rel="noopener">Python</a>, <a href="https://github.com/onboardiq/mcp_authorization_rust" class="text-github-accent hover:underline" target="_blank" rel="noopener">Rust</a>, and <a href="https://github.com/onboardiq/mcp-authorization-dotnet" class="text-github-accent hover:underline" target="_blank" rel="noopener">.NET</a> — giving MCP servers a consistent, ergonomic auth layer in whichever stack the team already runs. In Ruby, it compiles inline RBS annotations into foldable schemas that replace JSON Schema, and is backed by a formal <a href="https://raw.githubusercontent.com/AndyGauge/andygauge.github.io/master/publication/noninterference%20guarantee.pdf" class="text-github-accent hover:underline" target="_blank" rel="noopener">noninterference guarantee</a> (<a href="https://andygauge.github.io/noninterference-guarantee/" class="text-github-accent hover:underline" target="_blank" rel="noopener">slides</a>).</p>
           </div>
         </div>
       </div>
 
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Alternatives</h3>
       <!-- Sentinel RB -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -94,12 +99,13 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">Sentinel RB</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">Sentinel RB</h4>
             <p class="text-github-text-secondary leading-relaxed"><a href="https://github.com/andygauge/sentinel-rb" class="text-github-accent hover:underline" target="_blank" rel="noopener">sentinel-rb</a> is a system-level alternative to <a href="https://github.com/soutaro/rbs-inline" class="text-github-accent hover:underline" target="_blank" rel="noopener">rbs-inline</a> — a Rust-powered background watcher that keeps Ruby <code class="px-1 py-0.5 bg-github-bg rounded text-sm">.rbs</code> signatures in sync from inline annotations without interrupting your flow. It's fast enough to run as a pre-commit hook, asserting signatures are regenerated before code ever leaves your machine.</p>
           </div>
         </div>
       </div>
 
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Information Architecture</h3>
       <!-- sveltekitbook -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -109,7 +115,7 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">sveltekitbook</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">sveltekitbook</h4>
             <p class="text-github-text-secondary leading-relaxed">The runtime kernel behind every research book on this site — gestures, inline markdown, spectrum palette, and Giscus comments — published as <a href="https://www.npmjs.com/package/sveltekitbook" class="text-github-accent hover:underline" target="_blank" rel="noopener">sveltekitbook</a> on npm. Small on purpose: routes, cover, and per-page layout get scaffolded into each book as editable starter files instead of hiding behind a component API.</p>
           </div>
         </div>
@@ -124,7 +130,7 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">create-sveltekitbook</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">create-sveltekitbook</h4>
             <p class="text-github-text-secondary leading-relaxed">The scaffolder for the runtime above. <code class="px-1 py-0.5 bg-github-bg rounded text-sm">npm create sveltekitbook@latest my-book</code> walks a handful of prompts and drops a working SvelteKit book onto disk — cover, content pages, optional glossary / index / authors / topics, and a choice of <em>timeline</em>, <em>spectrum</em>, or flat continuum. Published as <a href="https://www.npmjs.com/package/create-sveltekitbook" class="text-github-accent hover:underline" target="_blank" rel="noopener">create-sveltekitbook</a> on npm.</p>
           </div>
         </div>
@@ -139,7 +145,7 @@
             </div>
           </div>
           <div class="flex-1">
-            <h3 class="text-lg font-semibold text-github-text mb-2">create-sveltekitslides</h3>
+            <h4 class="text-lg font-semibold text-github-text mb-2">create-sveltekitslides</h4>
             <p class="text-github-text-secondary leading-relaxed">The slide-deck sibling. <code class="px-1 py-0.5 bg-github-bg rounded text-sm">npm create sveltekitslides@latest my-talk</code> runs a presenter interview — length, audience, central claim, sections, demos, risks, takeaway, anticipated Q&amp;A — then scaffolds a SvelteKit deck where every slide is a long page: projected slide above the fold, rehearsal notes below it. Ships with a presentation timer, pace bar, QR code per slide, <code class="px-1 py-0.5 bg-github-bg rounded text-sm">/presenter</code> popout, optional phone↔laptop sync, and a Rust qrgen binary. Interview answers are baked into <code class="px-1 py-0.5 bg-github-bg rounded text-sm">PROMPT.md</code> so an LLM can finish drafting <code class="px-1 py-0.5 bg-github-bg rounded text-sm">outline.js</code>. Published as <a href="https://www.npmjs.com/package/create-sveltekitslides" class="text-github-accent hover:underline" target="_blank" rel="noopener">create-sveltekitslides</a> on npm.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add six section labels — Work / Research / Governance / Advocacy / Alternatives / Information Architecture — above their respective cards
- Demote card titles \`h3 → h4\` so section labels sit at \`h3\` under the section's \`h2\`

This commit landed on the branch after PR #14 merged, so master is missing it.

## Test plan
- [ ] Each group label renders as small uppercase muted text above its first card
- [ ] Card title styling unchanged (\`text-lg font-semibold\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)