### PR TITLE
Remap What I Do headings to action logics

### DIFF
--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -10,7 +10,7 @@
     
     <!-- Mastodon-inspired layout with alternating cards -->
     <div class="max-w-4xl mx-auto space-y-6">
-      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-2">Work</h3>
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-2">Strategist</h3>
       <!-- Multi-Agentic Systems -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -26,7 +26,7 @@
         </div>
       </div>
 
-      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Research</h3>
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Alchemist</h3>
       <!-- Déjà Vu -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -57,7 +57,7 @@
         </div>
       </div>
 
-      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Governance</h3>
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Achiever</h3>
       <!-- Rust Cookbook -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -73,7 +73,7 @@
         </div>
       </div>
 
-      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Advocacy</h3>
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Expert</h3>
       <!-- MCP Authorization -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -89,7 +89,7 @@
         </div>
       </div>
 
-      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Alternatives</h3>
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Individualist</h3>
       <!-- Sentinel RB -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">
@@ -105,7 +105,7 @@
         </div>
       </div>
 
-      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Information Architecture</h3>
+      <h3 class="text-xs font-semibold uppercase tracking-widest text-github-text-muted px-1 pt-4">Strategist</h3>
       <!-- sveltekitbook -->
       <div class="card p-6 hover:shadow-github transition-shadow duration-150">
         <div class="flex items-start space-x-4">


### PR DESCRIPTION
## Summary
Renames the six What I Do section headings using Rooke & Torbert's Hierarchy of Action Logics:

- **Strategist** — Multi-Agentic Systems
- **Alchemist** — Déjà Vu / AI For Good
- **Achiever** — Rust Cookbook
- **Expert** — MCP Authorization
- **Individualist** — Sentinel RB
- **Strategist** — sveltekitbook / create-sveltekitbook / create-sveltekitslides

Strategist appears twice; Alchemist appears once. Opportunist and Diplomat are absent on purpose.

## Test plan
- [ ] Each section heading renders the new label

🤖 Generated with [Claude Code](https://claude.com/claude-code)