### PR TITLE
Fix hero typing — render generated code as plaintext

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -50,6 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         new Typed('#typed-text', {
             strings: lines,
+            contentType: null,
             typeSpeed: 50,
             backSpeed: 30,
             backDelay: 2000,


### PR DESCRIPTION
## Summary
The hero stuck on \`By Degrees\` because Typed.js v2 was interpreting the code-generator's output as HTML — \`<h3>\`, \`<ul>\`, even Rust's \`&[i32]\` were getting parsed as DOM. Setting \`contentType: null\` makes Typed.js render strings literally.

## Test plan
- [ ] Hard-refresh; reload several times; confirm HTML, Ruby, Rust, and irb snippets all render as code